### PR TITLE
Fix a scaling issue on the video layer

### DIFF
--- a/akashi_engine/src/libakgraphics/backend/opengl/core/mvp.cpp
+++ b/akashi_engine/src/libakgraphics/backend/opengl/core/mvp.cpp
@@ -41,13 +41,13 @@ namespace akashi {
             GET_GLFUNC(ctx, glGetIntegerv)(GL_VIEWPORT, viewport);
             int screen_width = viewport[2];
             int screen_height = viewport[3];
-            double aspect = (double)tex.width / tex.height;
+            double aspect = (double)tex.effective_width / tex.effective_height;
             double scale_w = 1.0;
             double scale_h = 1.0;
 
-            if (tex.width < screen_width && tex.height < screen_height) {
-                scale_w = (double)tex.width / screen_width;
-                scale_h = (double)tex.height / screen_height;
+            if (tex.effective_width < screen_width && tex.height < screen_height) {
+                scale_w = (double)tex.effective_width / screen_width;
+                scale_h = (double)tex.effective_height / screen_height;
             } else if (screen_width > screen_height) {
                 // fixed height
                 scale_w = (screen_height * aspect) / screen_width;

--- a/akashi_engine/src/libakgraphics/backend/opengl/framebuffer.cpp
+++ b/akashi_engine/src/libakgraphics/backend/opengl/framebuffer.cpp
@@ -97,6 +97,8 @@ namespace akashi {
                                                  const FramebufferObject::Property& prop) const {
             tex.width = prop.width;
             tex.height = prop.height;
+            tex.effective_width = tex.width;
+            tex.effective_height = tex.height;
             tex.image = nullptr;
             tex.index = FramebufferObject::FBO_TEX_UNIT;
 

--- a/akashi_engine/src/libakgraphics/backend/opengl/gl.h
+++ b/akashi_engine/src/libakgraphics/backend/opengl/gl.h
@@ -211,8 +211,10 @@ namespace akashi {
             GLuint buffer;
             void* image = nullptr;
             void* surface = nullptr;
-            int width;
-            int height;
+            int width;  // includes stride
+            int height; // includes stdide
+            int effective_width;
+            int effective_height;
             GLenum format = GL_RGBA;
             GLenum internal_format = GL_RGBA;
         };

--- a/akashi_engine/src/libakgraphics/backend/opengl/layer.cpp
+++ b/akashi_engine/src/libakgraphics/backend/opengl/layer.cpp
@@ -126,6 +126,7 @@ namespace akashi {
                 return true;
             }
 
+            // [TODO] it stinks around here
             VTexSizeFormat size_format;
             size_format.video_width = buf_data->prop().width;
             size_format.video_height = buf_data->prop().height;
@@ -184,6 +185,9 @@ namespace akashi {
             tex.image = buf_data.prop().video_data[vdata_index].buf;
             tex.width = buf_data.prop().video_data[vdata_index].stride;
             tex.height = vdata_index == 0 ? buf_data.prop().height : buf_data.prop().chroma_height;
+            tex.effective_width =
+                vdata_index == 0 ? buf_data.prop().width : buf_data.prop().chroma_width;
+            tex.effective_height = tex.height;
             tex.format = GL_LUMINANCE;
             tex.internal_format = GL_LUMINANCE;
 
@@ -261,6 +265,8 @@ namespace akashi {
             tex.image = surface->pixels;
             tex.width = surface->w;
             tex.height = surface->h;
+            tex.effective_width = tex.width;
+            tex.effective_height = tex.height;
             tex.format = (surface->format->BytesPerPixel == 3) ? GL_RGB : GL_RGBA;
             tex.surface = surface;
 
@@ -317,6 +323,8 @@ namespace akashi {
             tex.image = surface->pixels;
             tex.width = surface->w;
             tex.height = surface->h;
+            tex.effective_width = surface->w;
+            tex.effective_height = surface->w;
             tex.format = (surface->format->BytesPerPixel == 3) ? GL_RGB : GL_RGBA;
             tex.surface = surface;
 

--- a/akashi_engine/src/libakgraphics/backend/opengl/render.cpp
+++ b/akashi_engine/src/libakgraphics/backend/opengl/render.cpp
@@ -38,7 +38,7 @@ namespace akashi {
             // activate fbo
             this->render_init(ctx, {fbo_prop.fbo, fbo_prop.width, fbo_prop.height});
 
-            // when new atom is came
+            // when new atom comes
             if (m_current_atom_uuid != frame_ctx.layer_ctxs[0].atom_uuid) {
                 AKLOG_DEBUG("new atom: old: {}, new: {}", m_current_atom_uuid,
                             frame_ctx.layer_ctxs[0].atom_uuid);
@@ -58,7 +58,7 @@ namespace akashi {
                 }
                 m_current_atom_uuid = frame_ctx.layer_ctxs[0].atom_uuid;
             }
-            // when exisiting atom is came
+            // when exisiting atom comes
             else {
                 for (const auto& layer_ctx : frame_ctx.layer_ctxs) {
                     auto it = m_target_map.find(layer_ctx.uuid);


### PR DESCRIPTION
A fix for #11.
As a workaround, we add `effective_width`, `effective_height` for `GLTextureData`.
When scaling, these fields will be used for the calculation.